### PR TITLE
Added es5 version of pda so will work with current node LTS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,19 @@
+{
+  "extends":"airbnb",
+  "parser": "babel-eslint",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "commonjs": true,
+    "mocha": true,
+  },
+  "rules": {
+    "max-len": 0,
+    "generator-star-spacing": 0,
+    "no-param-reassign": ["error", { "props": false }],
+    "no-restricted-syntax": 0,
+    "no-plusplus":0,
+    "no-console": 0,
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js"]}]
+  }
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
+node_modules/
 coverage/
+*.log
+.dat

--- a/example.js
+++ b/example.js
@@ -1,20 +1,20 @@
-var hyperdrive = require('hyperdrive')
-var discovery = require('hyperdiscovery')
-var storage = require('dat-storage')
-var Collections = require('./').default
+const hyperdrive = require('hyperdrive');
+const discovery = require('hyperdiscovery');
+const storage = require('dat-storage');
+const Collections = require('./').default;
 
-var key = 'ea17a8f2a05b6dc7f8556ec76b77b966004dec711c313bb8564a4895e2955cc0'
-var archive = hyperdrive(storage('.'), key, {latest: true, sparse: true})
-
-archive.on('ready', function () {
-  discovery(archive, {live: true}).on('connection', onconnection)
-})
+const key = 'ea17a8f2a05b6dc7f8556ec76b77b966004dec711c313bb8564a4895e2955cc0';
+const archive = hyperdrive(storage('.'), key, { latest: true, sparse: true });
 
 function onconnection() {
-  console.log('connected!')
+  console.log('connected!');
 }
 
-var c = new Collections(archive)
+archive.on('ready', () => {
+  discovery(archive, { live: true }).on('connection', onconnection);
+});
+
+const c = new Collections(archive);
 /*
 c.list().then(data => console.log(data)).catch(() => console.log('error'))
 c.subcollections('bad things').then(data => console.log(data)).catch(() => console.log('error'))
@@ -24,18 +24,16 @@ c.items('bad things', 'could be good things').then(data => console.log('could be
 c.allItems('bad things').then(data => console.log('all items', data)).catch(() => console.log('error'));
 */
 
-archive.metadata.on('ready', function () {
+archive.metadata.on('ready', () => {
   if (!archive.metadata.length) {
-    archive.metadata.on('sync', function() {
-      c.flatten().each(item => console.log(item[0],item[1]))
-    })
+    archive.metadata.on('sync', () => {
+      c.flatten().each(item => console.log(item[0], item[1]));
+    });
   } else {
-    c.flatten().each(item => console.log(item[0],item[1]))
+    c.flatten().each(item => console.log(item[0], item[1]));
   }
-})
+});
 
-
-
-c.on('updated', function() {
+c.on('updated', () => {
   // c.get('good things').then(data => console.log(data))
-})
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dat-storage": "^1.0.0",
     "hyperdiscovery": "^1.3.0",
     "hyperdrive": "^9.1.0",
+    "lodash": "^4.17.4",
     "pauls-dat-api": "^4.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
   },
   "homepage": "https://github.com/sdockray/dat-collections#README",
   "dependencies": {
-    "pauls-dat-api": "^4.1.1",
-    "bluebird": "^3.4.7"
+    "bluebird": "^3.4.7",
+    "dat-storage": "^1.0.0",
+    "hyperdiscovery": "^1.3.0",
+    "hyperdrive": "^9.1.0",
+    "pauls-dat-api": "^4.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -44,10 +47,6 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.9.0",
     "istanbul": "^1.0.0-alpha.2",
-    "mocha": "^3.3.0",
-    "tape": "^4.6.3",
-    "hyperdrive": "^9.1.0",
-    "hyperdiscovery": "^1.3.0",
-    "dat-storage": "^1.0.0"
+    "mocha": "^3.3.0"
   }
 }

--- a/src/collections.js
+++ b/src/collections.js
@@ -4,11 +4,11 @@ import pda from 'pauls-dat-api/es5';
 
 // Error handling for JSON parsing
 function jsonParse(str) {
-  let parsed = null;
   try {
-    parsed = JSON.parse(str)
-  } catch (error) {}
-  return parsed;
+    return JSON.parse(str)
+  } catch (error) {
+    return null;
+  }
 }
 
 // Given a path (through subcollections) in array form
@@ -46,7 +46,7 @@ function navigateJson(data, path, lastBranch = 'subcollections') {
 }
 
 // Default export class
-export default class extends EventEmitter {
+export default class Collections extends EventEmitter {
   constructor(archive, opts) {
     super();
     if (!opts) opts = {}

--- a/src/collections.js
+++ b/src/collections.js
@@ -1,6 +1,7 @@
 import Promise from 'bluebird';
 import EventEmitter from 'events';
 import pda from 'pauls-dat-api/es5';
+import get from 'lodash/get';
 
 // Error handling for JSON parsing
 function jsonParse(str) {
@@ -14,35 +15,16 @@ function jsonParse(str) {
 // Given a path (through subcollections) in array form
 // ["collection A", "subcollection B", "subcollection C"]
 // Get the object at A/B/C
-function navigateJson(data, path, lastBranch = 'subcollections') {
-  if (!data) {
-    return {};
-  }
-  if (path.length===0) {
-    return (lastBranch === 'subcollections') ? data : [];
-  }
-  let obj = data;
-  const lastPath = path.pop();
-  // Navigate the tree, following the path up until the last part
-  for (const p of path) {
-    if (p in obj && 'subcollections' in obj[p]) {
-      obj = obj[p].subcollections;
-    } else {
-      obj = [];
-    }
-  }
-  // Get into position for going down the last branch
-  if (lastPath && lastPath in obj) {
-    obj = obj[lastPath];
-  } else if (lastPath) {
-    obj = [];
-  }
-  if (lastBranch === 'subcollections' && obj && lastBranch in obj) {
-    obj = obj.subcollections;
-  } else if (obj && lastBranch in obj) {
-    obj = obj[lastBranch];
-  }
-  return Promise.resolve(obj);
+export function navigateJson(data, paths, lastBranch = 'subcollections') {
+  if (!data) return {};
+  if (!Array.isArray(paths) || paths.length === 0 ) return data;
+  const subcollectionPaths = paths.reduce((p, path, index) => {
+    if (index < paths.length - 1) p.push(path, 'subcollections');
+    else p.push(path);
+    return p;
+  }, []);
+  const result = get(data, subcollectionPaths);
+  return  result[lastBranch] || result;
 }
 
 // Default export class

--- a/src/collections.js
+++ b/src/collections.js
@@ -1,15 +1,6 @@
 import Promise from 'bluebird';
 import EventEmitter from 'events';
-import pda from 'pauls-dat-api';
-
-// Timeout for waiting
-const timeout = function (delay) {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      resolve()
-    }, delay)
-  })
-}
+import pda from 'pauls-dat-api/es5';
 
 // Error handling for JSON parsing
 function jsonParse(str) {

--- a/test/collections.test.js
+++ b/test/collections.test.js
@@ -1,0 +1,74 @@
+import chai from 'chai';
+import { navigateJson } from '../src/collections';
+
+const expect = chai.expect;
+
+describe('navigateJson function', () => {
+  const collectionJson = {
+    'collection name 1': [
+      'path/to/item 1',
+      'path/to/item 2',
+      'path/to/item 3',
+    ],
+    'collection name 2': {
+      subcollections: {
+        'subcollection name 1': [
+          'path/to/item 1',
+          'path/to/item 2',
+        ],
+        'subcollection name 2': [
+          'path/to/item 2',
+          'path/to/item 3',
+        ],
+      },
+      items: [
+        'path/to/item A',
+        'path/to/item B',
+      ],
+    },
+  };
+
+  it('returns the array of items if passed the path at root collection or tip of subcollections', () => {
+    expect(navigateJson(collectionJson, ['collection name 1']))
+      .to.eql([
+        'path/to/item 1',
+        'path/to/item 2',
+        'path/to/item 3',
+      ]);
+    expect(navigateJson(collectionJson, ['collection name 2', 'subcollection name 2']))
+      .to.eql([
+        'path/to/item 2',
+        'path/to/item 3',
+      ]);
+  });
+
+  it('returns subcollection object by reference if path has subcollection', () => {
+    expect(navigateJson(collectionJson, ['collection name 2']))
+      .to.be.a('object')
+      .and.have.all.keys([
+        'subcollection name 1',
+        'subcollection name 2',
+      ]);
+  });
+
+  it('optionally returns specific key of the subcollection object if present at path', () => {
+    expect(navigateJson(collectionJson, ['collection name 2'], 'items'))
+      .to.eql([
+        'path/to/item A',
+        'path/to/item B',
+      ]);
+  });
+
+  it('returns empty object if first argument is falsy', () => {
+    expect(navigateJson()).to.eql({});
+    expect(navigateJson(false)).to.eql({});
+    expect(navigateJson(0)).to.eql({});
+  });
+
+  it('returns first arguement if path is not an array or is empty', () => {
+    expect(navigateJson({ a: 'a' }, [])).to.eql({ a: 'a' });
+    expect(navigateJson(collectionJson, 1)).to.eql(collectionJson);
+    expect(navigateJson('woo', 'hello')).to.eql('woo');
+  });
+
+});


### PR DESCRIPTION
Also ended up playing around as I was curious how this was all working. 

- Wrote some tests for the function that gets subcollections. 
  We could simplify this by having subcollections as just named keys on the object, and `items` or something being a restricted key. This way we could avoid the reduce function, which splices subcollections into the path array.

- I also added eslint, but seriously just tell me if you dont want it. I understand style is totally opinionated and everyone has their own desires. We can also just choose rules we want to work with - http://eslint.org

- I added extra stuff to npmignore - as it does not inherit from gitignore we need to pretty much duplicate except for the dist directory. 